### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,33 @@ updates:
   - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
+
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
+
+    groups:
+      actions-artifacts:
+        IDENTIFIER: upload-download-artifact
+        patterns:
+          # these should be paired and upgrade together
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+      first-party:
+        patterns:
+          - "actions/*"
+
+      # no catch-all group: let everything else be standalone


### PR DESCRIPTION
Group the dev/prod python packages into a pair of PRs.

Keep the actions/upload-artifact and actions/download-artifacts actions together, since they usually need to be paired and update concurrently

Make the whole thing run once a quarter instead of monthly. It's intended to handle forgotten things, not hot-path.