### PR TITLE
Upgrade scrapy==2.16.0 and twisted==26.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,8 @@ updates:
       interval: "quarterly"
 
     groups:
-      development-dependencies:
-        dependency-type: "development"
-      production-dependencies:
-        dependency-type: "production"
+      dependencies:
+        dependency-type: "direct"
 
   - package-ecosystem: "pre-commit"
     directory: "/"

--- a/event_calendars/spiders/burlington_pools.py
+++ b/event_calendars/spiders/burlington_pools.py
@@ -5,9 +5,13 @@ import dateutil
 import scrapy
 from scrapy.exceptions import CloseSpider
 from scrapy.http import HtmlResponse, Response, TextResponse
+import scrapy.http
 from scrapy.http.request.form import FormdataType
 
 from ..items import BookableEvent
+
+class FormRequest(scrapy.http.FormRequest):  # TODO: Temporary shim for https://github.com/ellieayla/event-calendars/issues/72
+    ...
 
 
 def _parse_date_time(formatted_date: str, formatted_time: str) -> datetime:
@@ -44,7 +48,7 @@ class BurlingtonPools(scrapy.Spider):
         f"https://cityofburlington.perfectmind.com/22818/Clients/BookMe4BookingPages/Classes?calendarId={calendarId}&widgetId={widgetId}",
     ]
 
-    def parse(self, response: Response) -> scrapy.FormRequest:
+    def parse(self, response: Response) -> FormRequest:
         assert isinstance(response, HtmlResponse)  # guard because signature of parse() doesn't declare `response`
 
         # this page contains a form with an Input element "__RequestVerificationToken" whose value must be included on subsequent requests
@@ -60,14 +64,14 @@ class BurlingtonPools(scrapy.Spider):
             "__RequestVerificationToken": verification_token,
         }
 
-        return scrapy.FormRequest(
+        return FormRequest(
             url="https://cityofburlington.perfectmind.com/22818/Clients/BookMe4BookingPagesV2/ClassesV2",
             formdata=form_request_kv_data,
             callback=self.parse_classes_v2_json,
             cb_kwargs={"verification_token": verification_token},
         )
 
-    def parse_classes_v2_json(self, response: TextResponse, verification_token: str) -> Iterator[BookableEvent | scrapy.FormRequest]:
+    def parse_classes_v2_json(self, response: TextResponse, verification_token: str) -> Iterator[BookableEvent | FormRequest]:
         payload = response.json()
         # assert isinstance(self.crawler.stats, StatsCollector)  # TODO: just generate in Dataclass?
 
@@ -91,7 +95,7 @@ class BurlingtonPools(scrapy.Spider):
             yield b
 
         if payload["nextKey"] and payload["nextKey"] != "0001-01-01":
-            yield scrapy.FormRequest(
+            yield FormRequest(
                 url="https://cityofburlington.perfectmind.com/22818/Clients/BookMe4BookingPagesV2/ClassesV2",
                 formdata={
                     "calendarId": self.calendarId,

--- a/event_calendars/spiders/burlington_pools.py
+++ b/event_calendars/spiders/burlington_pools.py
@@ -3,12 +3,13 @@ from datetime import date, datetime, timedelta
 
 import dateutil
 import scrapy
+import scrapy.http
 from scrapy.exceptions import CloseSpider
 from scrapy.http import HtmlResponse, Response, TextResponse
-import scrapy.http
 from scrapy.http.request.form import FormdataType
 
 from ..items import BookableEvent
+
 
 class FormRequest(scrapy.http.FormRequest):  # TODO: Temporary shim for https://github.com/ellieayla/event-calendars/issues/72
     ...

--- a/event_calendars/spiders/burlington_pools.py
+++ b/event_calendars/spiders/burlington_pools.py
@@ -11,7 +11,7 @@ from scrapy.http.request.form import FormdataType
 from ..items import BookableEvent
 
 
-class FormRequest(scrapy.http.FormRequest):  # TODO: Temporary shim for https://github.com/ellieayla/event-calendars/issues/72
+class FormRequest(scrapy.http.FormRequest):  # TODO: Temporary shim for https://github.com/ellieayla/event-calendars/issues/73
     ...
 
 

--- a/event_calendars/spiders/toronto_community_bikeways.py
+++ b/event_calendars/spiders/toronto_community_bikeways.py
@@ -37,7 +37,7 @@ class TorontoCommunityBikeways(scrapy.Spider):
         try:
             content = response.css(".events-item .html-block")[0].root
             description = readable_text_content(content)
-        except (AttributeError, IndexError):
+        except AttributeError, IndexError:
             description = ""
 
         return scrapy.Request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "html2text>=2025.4.15",
     "humanize>=4.15.0",
     "icalendar>=7.0.0",
-    "scrapy>=2.15.2,<2.16",  # Wait for https://github.com/scrapy/form2request
+    "scrapy>=2.16.0",  # Wait for https://github.com/scrapy/form2request
     "waybackpy>=3.0.6",
 ]
 

--- a/tests/spiders/test_burlington_pools.py
+++ b/tests/spiders/test_burlington_pools.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 import pytest
-from scrapy import FormRequest, Request
+from scrapy import Request
 from scrapy.exceptions import CloseSpider
 from scrapy.http import HtmlResponse, TextResponse
 
 from event_calendars.items import BookableEvent
-from event_calendars.spiders.burlington_pools import BurlingtonPools
+from event_calendars.spiders.burlington_pools import BurlingtonPools, FormRequest
 
 FIXTURE_DIR = Path(__file__).parent.parent.parent.resolve() / "test_data"
 

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "html2text", specifier = ">=2025.4.15" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "icalendar", specifier = ">=7.0.0" },
-    { name = "scrapy", specifier = ">=2.15.2,<2.16" },
+    { name = "scrapy", specifier = ">=2.16.0" },
     { name = "waybackpy", specifier = ">=3.0.6" },
 ]
 
@@ -931,7 +931,7 @@ wheels = [
 
 [[package]]
 name = "scrapy"
-version = "2.15.2"
+version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -953,9 +953,9 @@ dependencies = [
     { name = "w3lib" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/ee/601014b8696e2e869c806d4377da6c468b278fd891b03fc5d1c830f2b641/scrapy-2.15.2.tar.gz", hash = "sha256:c7b8fc8d2c51a39d52f6025bdd7e9c714e43f97afd300e8c44157cf7a05c0c9e", size = 1291748, upload-time = "2026-04-28T13:29:54.141Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/a0/f710c21e87d64686f1b6d153eff7d1a2f7167bd94dd6c19aada07629fb38/scrapy-2.16.0.tar.gz", hash = "sha256:7287952a81fa302797ec0c3370a0096a8d81d4f9fe25a608a76df2a164511714", size = 1280834, upload-time = "2026-05-19T12:29:19.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/2c/b9d926e117765d84654efb5a8280379e76a681338155c5c79578b4b207ac/scrapy-2.15.2-py3-none-any.whl", hash = "sha256:ff47379299699f1fcc7bc1d404754306f04371d0822e077c2857777d60743e07", size = 352868, upload-time = "2026-04-28T13:29:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c9/7cc7631ca85c08b7e1162e1e08ecb0c139f8f640cc403257ac500a8e50fe/scrapy-2.16.0-py3-none-any.whl", hash = "sha256:fcb83db5500743503b1fea4d55c81aac056b15481d0aad46b6f929d324d9bcf5", size = 344254, upload-time = "2026-05-19T12:29:17.206Z" },
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "25.5.0"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1008,9 +1008,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/0f/82716ed849bf7ea4984c21385597c949944f0f9b428b5710f79d0afc084d/twisted-25.5.0.tar.gz", hash = "sha256:1deb272358cb6be1e3e8fc6f9c8b36f78eb0fa7c2233d2dbe11ec6fee04ea316", size = 3545725, upload-time = "2025-06-07T09:52:24.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/66/ab7efd8941f0bc7b2bd555b0f0471bff77df4c88e0cc31120c82737fec77/twisted-25.5.0-py3-none-any.whl", hash = "sha256:8559f654d01a54a8c3efe66d533d43f383531ebf8d81d9f9ab4769d91ca15df7", size = 3204767, upload-time = "2025-06-07T09:52:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes issue #72
    
Temporary FormRequest class can be removed when migrating to https://github.com/scrapy/form2request
    
See https://github.com/ellieayla/event-calendars/issues/73
