### PR TITLE
Upgrade scrapy to 2.17.0

### DIFF
--- a/event_calendars/spiders/burlington_pools.py
+++ b/event_calendars/spiders/burlington_pools.py
@@ -3,16 +3,11 @@ from datetime import date, datetime, timedelta
 
 import dateutil
 import scrapy
-import scrapy.http
 from scrapy.exceptions import CloseSpider
-from scrapy.http import HtmlResponse, Response, TextResponse
+from scrapy.http import FormRequest, HtmlResponse, Response, TextResponse
 from scrapy.http.request.form import FormdataType
 
 from ..items import BookableEvent
-
-
-class FormRequest(scrapy.http.FormRequest):  # TODO: Temporary shim for https://github.com/ellieayla/event-calendars/issues/73
-    ...
 
 
 def _parse_date_time(formatted_date: str, formatted_time: str) -> datetime:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "html2text>=2025.4.15",
     "humanize>=4.15.0",
     "icalendar>=7.0.0",
-    "scrapy>=2.16.0",  # Wait for https://github.com/scrapy/form2request
+    "scrapy>=2.17.0",
     "waybackpy>=3.0.6",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "html2text", specifier = ">=2025.4.15" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "icalendar", specifier = ">=7.0.0" },
-    { name = "scrapy", specifier = ">=2.16.0" },
+    { name = "scrapy", specifier = ">=2.17.0" },
     { name = "waybackpy", specifier = ">=3.0.6" },
 ]
 
@@ -931,7 +931,7 @@ wheels = [
 
 [[package]]
 name = "scrapy"
-version = "2.16.0"
+version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -953,9 +953,9 @@ dependencies = [
     { name = "w3lib" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/a0/f710c21e87d64686f1b6d153eff7d1a2f7167bd94dd6c19aada07629fb38/scrapy-2.16.0.tar.gz", hash = "sha256:7287952a81fa302797ec0c3370a0096a8d81d4f9fe25a608a76df2a164511714", size = 1280834, upload-time = "2026-05-19T12:29:19.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/9f/9800513193aacb44825f0b9a75e4e6d4a0c416e9ed23ca3aac7374d03d17/scrapy-2.17.0.tar.gz", hash = "sha256:b536d14166b05e2183b19ae105a7af849cd14d4c1f70d3009d9b1828c0ab3d92", size = 1312077, upload-time = "2026-07-07T10:27:43.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/c9/7cc7631ca85c08b7e1162e1e08ecb0c139f8f640cc403257ac500a8e50fe/scrapy-2.16.0-py3-none-any.whl", hash = "sha256:fcb83db5500743503b1fea4d55c81aac056b15481d0aad46b6f929d324d9bcf5", size = 344254, upload-time = "2026-05-19T12:29:17.206Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e8/30fbfcb45b35da9e24c6f1ae193688dc834cef3fd576a41d3a08ef771125/scrapy-2.17.0-py3-none-any.whl", hash = "sha256:a650a59e9425e7e4b4d59083f858df34ec9a5a8292b3e35671d444fb56fe5085", size = 350445, upload-time = "2026-07-07T10:27:41.59Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Remove the FormRequest shim, now that https://github.com/scrapy/scrapy/pull/7671 has undeprecated the basic FormRequest API

Eliminates need for
* #73 